### PR TITLE
Fix persistent flag parsing for subcommands

### DIFF
--- a/command.go
+++ b/command.go
@@ -154,8 +154,49 @@ func (c *Command) inheritPersistentFlags(flags *FlagSet) {
 		c.parent.inheritPersistentFlags(flags)
 	}
 
-	if c.SetPersistentFlags != nil {
-		c.SetPersistentFlags(flags)
+	if c.SetPersistentFlags == nil {
+		return
+	}
+
+	// Snapshot values of flags already parsed on this command's own FlagSet.
+	// SetPersistentFlags re-registers flags via BoolVar/StringVar/etc., which
+	// resets the bound variable to its default. After registration we restore
+	// the snapshot so that already-parsed values survive the re-registration.
+	saved := snapshotSetFlags(c.flags)
+
+	c.SetPersistentFlags(flags)
+
+	restoreSetFlags(flags, saved)
+}
+
+// snapshotSetFlags captures the current name-value pairs of all defined flags.
+// It uses VisitAll (not Visit) because a persistent flag may have been parsed
+// by a different ancestor than the one that defined it.
+func snapshotSetFlags(fs *FlagSet) map[string]string {
+	if fs == nil {
+		return nil
+	}
+
+	var m map[string]string
+
+	fs.VisitAll(func(f *flag.Flag) {
+		if m == nil {
+			m = make(map[string]string)
+		}
+
+		m[f.Name] = f.Value.String()
+	})
+
+	return m
+}
+
+// restoreSetFlags writes previously-snapshotted values back into fs.
+func restoreSetFlags(fs *FlagSet, saved map[string]string) {
+	for name, val := range saved {
+		if f := fs.Lookup(name); f != nil {
+			//nolint:errcheck // Value was already parsed successfully; Set cannot fail here.
+			f.Value.Set(val)
+		}
 	}
 }
 
@@ -176,18 +217,21 @@ func (c *Command) execCommand(args []string) error {
 		}
 	}
 
-	// Check if the positional arguments is a subcommand.
-	if len(args) > 0 && len(c.subcommands) > 0 {
-		if subcommand, ok := c.subcommands[args[0]]; ok {
+	// Check if the remaining positional arguments contain a subcommand.
+	// Use c.Flags().Args() (post-parse remainder) instead of raw args so that
+	// persistent flags consumed during parsing are excluded from the lookup.
+	remaining := c.Flags().Args()
+	if len(remaining) > 0 && len(c.subcommands) > 0 {
+		if subcommand, ok := c.subcommands[remaining[0]]; ok {
 			// Subcommand has been found and should be executed.
-			return subcommand.execCommand(args[1:])
+			return subcommand.execCommand(remaining[1:])
 		}
 
-		// Looks line the argument is not it the list of known subcommands.
+		// Looks like the argument is not in the list of known subcommands.
 		// Let's print the usage and return an error.
 		c.flags.Usage()
 
-		return fmt.Errorf("unknown command: %s", args[0])
+		return fmt.Errorf("unknown command: %s", remaining[0])
 	}
 
 	if c.Run == nil {

--- a/command_test.go
+++ b/command_test.go
@@ -391,6 +391,126 @@ func TestCommand_SetPersistentFlags(t *testing.T) {
 		}
 	})
 
+	t.Run("Persistent flag between subcommands", func(t *testing.T) {
+		var verbose bool
+		var called bool
+
+		root := &Command{
+			Name: "root",
+			SetPersistentFlags: func(flags *FlagSet) {
+				flags.BoolVar(&verbose, "verbose", false, "verbose output")
+			},
+		}
+
+		sub := &Command{
+			Name: "sub",
+			Run: func(cmd *Command, args []string) error {
+				called = true
+				return nil
+			},
+		}
+
+		root.AddSubcommands(sub)
+
+		got := root.execCommand([]string{"-verbose", "sub"})
+		if got != nil {
+			t.Fatalf("Unexpected error: %v", got)
+		}
+
+		if !verbose {
+			t.Error("Expected verbose to be true, got false")
+		}
+
+		if !called {
+			t.Error("Expected subcommand Run to be called")
+		}
+	})
+
+	t.Run("Persistent flag before subcommand in chain", func(t *testing.T) {
+		var verbose bool
+		var called bool
+
+		root := &Command{
+			Name: "root",
+			SetPersistentFlags: func(flags *FlagSet) {
+				flags.BoolVar(&verbose, "verbose", false, "verbose output")
+			},
+		}
+
+		mid := &Command{Name: "mid"}
+		leaf := &Command{
+			Name: "leaf",
+			Run: func(cmd *Command, args []string) error {
+				called = true
+				return nil
+			},
+		}
+
+		root.AddSubcommands(mid)
+		mid.AddSubcommands(leaf)
+
+		got := root.execCommand([]string{"mid", "-verbose", "leaf"})
+		if got != nil {
+			t.Fatalf("Unexpected error: %v", got)
+		}
+
+		if !verbose {
+			t.Error("Expected verbose to be true, got false")
+		}
+
+		if !called {
+			t.Error("Expected leaf Run to be called")
+		}
+	})
+
+	t.Run("Multi-level persistent flags between subcommands", func(t *testing.T) {
+		var verbose bool
+		var format string
+		var called bool
+
+		root := &Command{
+			Name: "root",
+			SetPersistentFlags: func(flags *FlagSet) {
+				flags.BoolVar(&verbose, "verbose", false, "verbose output")
+			},
+		}
+
+		mid := &Command{
+			Name: "mid",
+			SetPersistentFlags: func(flags *FlagSet) {
+				flags.StringVar(&format, "format", "text", "output format")
+			},
+		}
+
+		leaf := &Command{
+			Name: "leaf",
+			Run: func(cmd *Command, args []string) error {
+				called = true
+				return nil
+			},
+		}
+
+		root.AddSubcommands(mid)
+		mid.AddSubcommands(leaf)
+
+		got := root.execCommand([]string{"mid", "-verbose", "-format", "json", "leaf"})
+		if got != nil {
+			t.Fatalf("Unexpected error: %v", got)
+		}
+
+		if !verbose {
+			t.Error("Expected verbose to be true, got false")
+		}
+
+		if format != "json" {
+			t.Errorf("Expected format to be 'json', got '%s'", format)
+		}
+
+		if !called {
+			t.Error("Expected leaf Run to be called")
+		}
+	})
+
 	t.Run("Available on defining command itself", func(t *testing.T) {
 		var verbose bool
 

--- a/usage.go
+++ b/usage.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"reflect"
-	"sort"
+	"slices"
 	"strings"
 	"unicode/utf8"
 )
@@ -113,8 +113,8 @@ func sortedSubcommands(subcommands map[string]*Command) []*Command {
 		commands = append(commands, cmd)
 	}
 
-	sort.Slice(commands, func(i, j int) bool {
-		return commands[i].Name < commands[j].Name
+	slices.SortFunc(commands, func(a, b *Command) int {
+		return strings.Compare(a.Name, b.Name)
 	})
 
 	return commands


### PR DESCRIPTION
When persistent flags appear before subcommand names in args, they were incorrectly treated as positional args during subcommand lookup. Now uses Flags().Args() to get the post-parse remainder instead of raw args.

Also fixes flag value reset issue: snapshotting flag values before SetPersistentFlags re-registers them, then restoring after to preserve already-parsed values.